### PR TITLE
[Hotfix] Added fetch-depth and fetch-tags options to checkout step to make cookbook build multi version

### DIFF
--- a/.github/workflows/cookbook.yml
+++ b/.github/workflows/cookbook.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
## Description
Added fetch-depth and fetch-tags options to checkout step to make cookbook build multi version

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [x] Documentation
- [ ] Tests
- [x] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review
