### PR TITLE
[Hotfix] Fix dependency with Agno

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ langgraph = [
 ]
 
 agno = [
-    "agno>=1.7.5",
+    "agno>=1.7.5,<2.0.0",
 ]
 a2a = [
     "a2a-sdk>=0.3.0",


### PR DESCRIPTION
## Description
This is a quick fix for Agno version compatibility. Due to the breaking changes introduced in Agno version [2.0.0](https://docs.agno.com/how-to/v2-changelog), we need to pin the dependency to versions prior to 2.0.0 to maintain compatibility with our current codebase.


## Changes
Updated Agno dependency constraint from `agno>=1.7.5` to `agno>=1.7.5,<2.0.0`. This ensures we use Agno versions between 1.7.5 and 1.x.x, excluding 2.0.0 and above.


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [ ] Documentation
- [ ] Tests
- [x] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review