### PR TITLE
[Hotfix] Fix `TypeError: agentscope.agent._react_agent.ReActAgent() got multiple values for keyword argument` when using Toolkit in agent_config

### DIFF
--- a/src/agentscope_runtime/engine/agents/agentscope_agent/agent.py
+++ b/src/agentscope_runtime/engine/agents/agentscope_agent/agent.py
@@ -247,7 +247,7 @@ class AgentScopeAgent(Agent):
         try:
             sig = inspect.signature(
                 builder_cls.__init__,
-            )  # 对类用 __init__，对函数用自己
+            )
             allowed_params = set(sig.parameters.keys())
             allowed_params.discard("self")
         except (TypeError, ValueError):


### PR DESCRIPTION
## Description

* Fix `TypeError: agentscope.agent._react_agent.ReActAgent() got multiple values for keyword argument`

* Fix subclass error.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Engine
- [ ] Sandbox
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review
