### PR TITLE
[Hotfix] Fix UT Failed 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ autogen = [
 
 langchain_rag=[
     "langchain>=0.3.25",
-    "pymilvus>=2.6.0",
+    "pymilvus[milvus-lite]>=2.6.0",
     "langchain-community>=0.3.27",
     "langchain-milvus>=0.2.1",
     "bs4>=0.0.2",
@@ -77,7 +77,7 @@ langchain_rag=[
 
 llamaindex_rag=[
     "llama-index>=0.13.4",
-    "pymilvus>=2.6.0",
+    "pymilvus[milvus-lite]>=2.6.0",
     "llama-index-vector-stores-milvus>=0.9.1",
     "llama-index-readers-web>=0.5.1",
     "llama-index-embeddings-langchain>=0.4.0",


### PR DESCRIPTION
## Description
issue (before): https://github.com/agentscope-ai/agentscope-runtime/actions/runs/17995945470/job/51195388277

now (after): https://github.com/rayrayraykk/agentscope-runtime/actions/runs/17998586261/job/51202733532
```
=========================== short test summary info ============================
FAILED tests/unit/test_rag_service.py::test_langchain_from_docs - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=milvus-lite is required for local database connections. Please install it with: pip install pymilvus[milvus_lite])>
FAILED tests/unit/test_rag_service.py::test_langchain_from_db - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=milvus-lite is required for local database connections. Please install it with: pip install pymilvus[milvus_lite])>
FAILED tests/unit/test_rag_service.py::test_llamaindex_from_docs - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=milvus-lite is required for local database connections. Please install it with: pip install pymilvus[milvus_lite])>
FAILED tests/unit/test_rag_service.py::test_llamaindex_from_db - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=milvus-lite is required for local database connections. Please install it with: pip install pymilvus[milvus_lite])>
FAILED tests/unit/test_rag_service.py::test_rag - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=milvus-lite is required for local database connections. Please install it with: pip install pymilvus[milvus_lite])>
====== 5 failed, 98 passed, 41 skipped, 327 warnings in 330.32s (0:05:30) ======
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [ ] Documentation
- [x] Tests
- [x] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review
