### PR TITLE
[HotFix] Correct Pydantic v2 `@model_validator(mode="after")` signature to avoid AttributeError

### DIFF
--- a/src/agentscope_runtime/sandbox/model/manager_config.py
+++ b/src/agentscope_runtime/sandbox/model/manager_config.py
@@ -120,7 +120,7 @@ class SandboxManagerEnvConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_settings(cls, self):
+    def check_settings(self):
         if self.default_mount_dir:
             os.makedirs(self.default_mount_dir, exist_ok=True)
 


### PR DESCRIPTION
## Description
In **Pydantic v2**, the `@model_validator(mode="after")` method in `SandboxManagerEnvConfig` was defined as:

```python
@model_validator(mode="after")
def check_settings(cls, self):
    ...
```

This is an **invalid signature** for v2.
For `mode="after"`, the first parameter should be the **model instance** (`self`), not `cls`.

With the current implementation, Pydantic passes the model instance into the first parameter (`cls`), and the second parameter (`self`) ends up being a `ValidationInfo` object. This causes:

```
AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'default_mount_dir'
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [x] Sandbox
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
[How to test these changes]

## Additional Notes
[Optional: any other context]