### PR TITLE
fix langgraph agent state

### DIFF
--- a/src/agentscope_runtime/engine/agents/langgraph_agent.py
+++ b/src/agentscope_runtime/engine/agents/langgraph_agent.py
@@ -3,61 +3,65 @@ import json
 
 from langgraph.graph.state import CompiledStateGraph
 
+from ..schemas.agent_schemas import Message, TextContent
 from .base_agent import Agent
-from ..schemas.agent_schemas import (
-    Message,
-    TextContent,
-)
 
 
 def _state_folder(messages):
-    if len(messages) > 0:
-        content = messages[0]["content"]
-        # If content is a list (containing text objects), extract the text content
-        if isinstance(content, list) and len(content) > 0:
-            # Assume the first element is of text type
-            if isinstance(content[0], dict) and content[0].get("type") == "text":
-                text_content = content[0].get("text", "")
-                return {"messages": [{"role": messages[0]["role"], "content": text_content}]}
-            else:
-                # If not text type, convert to string
-                return {"messages": [{"role": messages[0]["role"], "content": str(content)}]}
-        # If content is a string, try to parse it as JSON, if failed, return directly
-        elif isinstance(content, str):
-            try:
-                return json.loads(content)
-            except json.JSONDecodeError:
-                # If not valid JSON, return the original string
-                return {"messages": [{"role": messages[0]["role"], "content": content}]}
-        # If content is already a dictionary or other type, return directly
-        elif isinstance(content, dict):
-            return content
-        else:
-            # For other cases, wrap in messages and return
-            return {"messages": [{"role": messages[0]["role"], "content": str(content)}]}
-    else:
+    if not messages or len(messages) == 0:
         # Return empty list if no messages
         return []
+
+    content = messages[0]["content"]
+    role = messages[0]["role"]
+
+    # If content is a list, extract the text content
+    if isinstance(content, list) and len(content) > 0:
+        if isinstance(content[0], dict) and content[0].get("type") == "text":
+            text_content = content[0].get("text", "")
+        else:
+            # If not text type, convert to string
+            text_content = str(content)
+        return {"messages": [{"role": role, "content": text_content}]}
+
+    # If content is string, parse it as JSON, if failed, return directly
+    if isinstance(content, str):
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            # If not valid JSON, return the original string
+            return {"messages": [{"role": role, "content": content}]}
+
+    # If content is already a dictionary, return directly
+    if isinstance(content, dict):
+        return content
+
+    # For other cases, wrap in messages and return
+    return {"messages": [{"role": role, "content": str(content)}]}
 
 
 def _state_unfolder(state):
     # Process state that may contain non-serializable objects
     def default_serializer(obj):
         # If object has __dict__ method, use it
-        if hasattr(obj, '__dict__'):
+        if hasattr(obj, "__dict__"):
             return obj.__dict__
         # If object has model_dump method, use it
-        elif hasattr(obj, 'model_dump'):
+        elif hasattr(obj, "model_dump"):
             return obj.model_dump()
         # If object is a message type, extract its content
-        elif hasattr(obj, 'content'):
+        elif hasattr(obj, "content"):
             return str(obj.content)
         # For other cases, convert to string
         else:
             return str(obj)
 
     # Serialize state to JSON string with custom serializer
-    state_jsons = json.dumps(state, default=default_serializer, ensure_ascii=False)
+    state_jsons = json.dumps(
+        state,
+        default=default_serializer,
+        ensure_ascii=False,
+    )
     return state_jsons
 
 


### PR DESCRIPTION
## Description
When using the `LangGraphAgent` class, the following error occurs. Upon investigation, the issue stems from improper handling of methods related to `langgraph.graph.state`. Specifically, classes such as `HumanMessage` do not support direct serialization：

Traceback (most recent call last):
  File "/mnt/workspace/proj2/langgraph/zh-CN/langgraph_react_agent.py", line 207, in <module>
    asyncio.run(test_interaction())
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/mnt/workspace/proj2/langgraph/zh-CN/langgraph_react_agent.py", line 194, in test_interaction
    async for response in interact_with_agent(runner):
  File "/mnt/workspace/proj2/langgraph/zh-CN/langgraph_react_agent.py", line 179, in interact_with_agent
    async for message in runner.stream_query(request=request):
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/tracing/wrapper.py", line 195, in async_iter_task
    raise e
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/tracing/wrapper.py", line 191, in async_iter_task
    async for resp in iter_entry():
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/tracing/wrapper.py", line 188, in iter_entry
    raise e
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/tracing/wrapper.py", line 148, in iter_entry
    async for i, resp in aenumerate(
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/tracing/wrapper.py", line 39, in aenumerate
    async for elem in asequence:
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/runner.py", line 171, in stream_query
    async for event in context.agent.run_async(context):
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/agents/langgraph_agent.py", line 75, in run_async
    content = self.state_unfolder(output)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/agentscope_runtime/engine/agents/langgraph_agent.py", line 43, in _state_unfolder
    state_jsons = json.dumps(state)
                  ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type HumanMessage is not JSON serializable


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Engine
- [ ] Sandbox
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing
build a LangGraphAgent and run it
