### PR TITLE
fix agentscope FunctionCallOutput

### DIFF
--- a/src/agentscope_runtime/engine/agents/agentscope_agent.py
+++ b/src/agentscope_runtime/engine/agents/agentscope_agent.py
@@ -444,7 +444,7 @@ class AgentScopeAgent(Agent):
                                 index=index,
                                 data=FunctionCallOutput(
                                     call_id=element.get("id"),
-                                    output=str(element.get("output")),
+                                    output=json.dumps(element.get("output")),
                                 ).model_dump(),
                             )
                             plugin_output_message = Message(


### PR DESCRIPTION
## Description
For dict outputs of function call, `str()` does not handle it in a right way.

**Related Issue:** Fixes #175 

**Security Considerations:** [If applicable, especially for sandbox changes]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Engine
- [ ] Sandbox
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [ ] Pre-commit hooks pass
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing
[How to test these changes]

## Additional Notes
[Optional: any other context]