### PR TITLE
Fix tool use name assignment in agentscope_agent.py

### DIFF
--- a/src/agentscope_runtime/engine/agents/agentscope_agent.py
+++ b/src/agentscope_runtime/engine/agents/agentscope_agent.py
@@ -115,7 +115,7 @@ class AgentScopeContextAdapter:
                 ToolUseBlock(
                     type="tool_use",
                     id=message.content[0].data["call_id"],
-                    name=message.role,
+                    name=message.content[0].data["name"],
                     input=json.loads(message.content[0].data["arguments"]),
                 ),
             ]


### PR DESCRIPTION
## Description

In `AgentscopeContextAdapter.converter`,
the name of ToolUseBlock should be the name of the tool or function, not the role of the msg.

**Related Issue:** Fixes #139 

**Security Considerations:** [If applicable, especially for sandbox changes]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Engine
- [ ] Sandbox
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [ ] Pre-commit hooks pass
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing
[How to test these changes]

## Additional Notes
[Optional: any other context]