### PR TITLE
feat: allow user to disable tracing console log

### DIFF
--- a/src/agentscope_runtime/engine/tracing/wrapper.py
+++ b/src/agentscope_runtime/engine/tracing/wrapper.py
@@ -890,7 +890,7 @@ def _get_tracer() -> Tracer:
         handlers.append(
             LocalLogHandler(
                 enable_console=_str_to_bool(
-                    os.getenv("TRACE_ENABLE_CONSOLE_LOG", "true")
+                    os.getenv("TRACE_ENABLE_CONSOLE_LOG", "false")
                 )
             )
         )


### PR DESCRIPTION
## Description

By default, tracing logs are enabled and log to both files and the console simultaneously. This PR allows users to disable console logging while retaining file logging

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [ ] Pre-commit hooks pass
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

## Additional Notes