### PR TITLE
hotfix:  Fix tests by using per‑function event loops to prevent agno “Event loop is closed” errors

### DIFF
--- a/tests/integrated/test_runner_stream_agno.py
+++ b/tests/integrated/test_runner_stream_agno.py
@@ -12,12 +12,6 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
     RunStatus,
 )
 from agentscope_runtime.engine.runner import Runner
-from agentscope_runtime.engine.services.agent_state import (
-    InMemoryStateService,
-)
-from agentscope_runtime.engine.services.session_history import (
-    InMemorySessionHistoryService,
-)
 from agentscope_runtime.engine.services.sandbox import SandboxService
 
 
@@ -78,19 +72,13 @@ class MyRunner(Runner):
         """
         Init handler.
         """
-        self.state_service = InMemoryStateService()
-        self.session_service = InMemorySessionHistoryService()
         self.sandbox_service = SandboxService()
-        await self.state_service.start()
-        await self.session_service.start()
         await self.sandbox_service.start()
 
     async def shutdown_handler(self, *args, **kwargs):
         """
         Shutdown handler.
         """
-        await self.state_service.stop()
-        await self.session_service.stop()
         await self.sandbox_service.stop()
 
 

--- a/tests/integrated/test_runner_stream_agno_thinking.py
+++ b/tests/integrated/test_runner_stream_agno_thinking.py
@@ -12,12 +12,6 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
     RunStatus,
 )
 from agentscope_runtime.engine.runner import Runner
-from agentscope_runtime.engine.services.agent_state import (
-    InMemoryStateService,
-)
-from agentscope_runtime.engine.services.session_history import (
-    InMemorySessionHistoryService,
-)
 from agentscope_runtime.engine.services.sandbox import SandboxService
 
 
@@ -79,19 +73,13 @@ class MyRunner(Runner):
         """
         Init handler.
         """
-        self.state_service = InMemoryStateService()
-        self.session_service = InMemorySessionHistoryService()
         self.sandbox_service = SandboxService()
-        await self.state_service.start()
-        await self.session_service.start()
         await self.sandbox_service.start()
 
     async def shutdown_handler(self, *args, **kwargs):
         """
         Shutdown handler.
         """
-        await self.state_service.stop()
-        await self.session_service.stop()
         await self.sandbox_service.stop()
 
 


### PR DESCRIPTION
## Description
When running our integration tests `test_runner_sample1` and `test_runner_sample2` with `pytest-asyncio`’s default **session‑scoped** event loop, intermittent failures occurred with the error:

```
agno.exceptions.ModelProviderError: Event loop is closed
RuntimeError: Event loop is closed
```

These errors originate from agno’s streaming model execution (`agent.arun` → `model.ainvoke_stream`), which uses HTTPX/anyio for async network I/O.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [x] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
[How to test these changes]

## Additional Notes
[Optional: any other context]