### PR TITLE
Fix: support VNC remote desktop with custom URL prefix

### DIFF
--- a/src/agentscope_runtime/sandbox/box/gui/box/vnc_relay.html
+++ b/src/agentscope_runtime/sandbox/box/gui/box/vnc_relay.html
@@ -107,10 +107,25 @@
 
         function getSandboxIdFromPath() {
             const pathParts = window.location.pathname.split('/');
-            if (pathParts.length >= 3 && pathParts[1] === 'desktop') {
-                return pathParts[2];
+            // Find 'desktop' anywhere in the path to support arbitrary URL prefixes
+            // Supports: /desktop/{sandbox_id}/... or /custom/prefix/desktop/{sandbox_id}/...
+            const desktopIndex = pathParts.indexOf('desktop');
+            if (desktopIndex !== -1 && pathParts.length > desktopIndex + 1) {
+                return pathParts[desktopIndex + 1];
             }
             return null;
+        }
+
+        function getWebSocketPath(sandbox_id) {
+            // Extract the path prefix up to and including /desktop/{sandbox_id}
+            // This preserves any custom URL prefix for reverse proxy deployments
+            const currentPath = window.location.pathname;
+            const desktopMatch = currentPath.match(/(.*)\/desktop\/([^\/]+)/);
+            if (desktopMatch) {
+                return desktopMatch[1] + '/desktop/' + desktopMatch[2];
+            }
+            // Fallback to simple path
+            return '/desktop/' + sandbox_id;
         }
 
         document.getElementById('sendCtrlAltDelButton')
@@ -141,7 +156,7 @@
             url += ':' + port;
         }
 
-        url += '/desktop/' + sandbox_id;
+        url += getWebSocketPath(sandbox_id);
 
         if (path && path !== 'websockify') {
             url += '?path=' + encodeURIComponent(path);


### PR DESCRIPTION
## Description
Fix VNC remote desktop not working when using custom URL prefix in remote sandbox manager mode.

When deploying sandbox manager behind a reverse proxy with custom URL prefix (e.g., `/my-service/v1/desktop/{sandbox_id}/vnc/vnc_relay.html`), the VNC viewer fails to connect because:
1. `getSandboxIdFromPath()` assumes sandbox_id is at fixed position in path
2. WebSocket URL construction hardcodes `/desktop/{sandbox_id}` path

This PR modifies `vnc_relay.html` to:
- Find 'desktop' anywhere in the URL path to extract sandbox_id
- Preserve the full URL prefix for WebSocket connection

**Related Issue:** Fixes #321 

**Security Considerations:** No security impact. This change only affects URL path parsing logic.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [x] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing
1. Deploy sandbox manager behind a reverse proxy with custom URL prefix
2. Access VNC viewer via: `https://your-domain/custom/prefix/desktop/{sandbox_id}/vnc/vnc_relay.html`
3. Verify VNC connection establishes successfully
4. Also verify backward compatibility with simple path: `/desktop/{sandbox_id}/vnc/vnc_relay.html`

## Additional Notes
- No automated tests added as this is a static HTML/JavaScript file
- The project does not have a frontend testing framework
- Changes are backward compatible with existing deployments