### PR TITLE
Use aclose for Redis async clients

### DIFF
--- a/src/agentscope_runtime/engine/services/agent_state/redis_state_service.py
+++ b/src/agentscope_runtime/engine/services/agent_state/redis_state_service.py
@@ -38,7 +38,7 @@ class RedisStateService(StateService):
     async def stop(self) -> None:
         """Close the Redis connection."""
         if self._redis:
-            await self._redis.close()
+            await self._redis.aclose()
             self._redis = None
         self._health = False
 

--- a/src/agentscope_runtime/engine/services/memory/redis_memory_service.py
+++ b/src/agentscope_runtime/engine/services/memory/redis_memory_service.py
@@ -33,7 +33,7 @@ class RedisMemoryService(MemoryService):
     async def stop(self) -> None:
         """Closes the Redis connection."""
         if self._redis:
-            await self._redis.close()
+            await self._redis.aclose()
             self._redis = None
 
     async def health(self) -> bool:

--- a/src/agentscope_runtime/engine/services/session_history/redis_session_history_service.py
+++ b/src/agentscope_runtime/engine/services/session_history/redis_session_history_service.py
@@ -28,7 +28,7 @@ class RedisSessionHistoryService(SessionHistoryService):
 
     async def stop(self):
         if self._redis:
-            await self._redis.close()
+            await self._redis.aclose()
             self._redis = None
 
     async def health(self) -> bool:


### PR DESCRIPTION
## What happened
On shutdown, AgentScope Runtime logs warnings from redis-py >=5.0.1:

```
DeprecationWarning: Call to deprecated close. (Use aclose() instead)
```

### Console

```
INFO:agentscope_runtime.engine.deployers.local_deployer:Stopping FastAPI daemon thread service...
INFO:     Shutting down
INFO:     Waiting for application shutdown.
/xxxxxxxxx/.venv/lib/python3.14/site-packages/agentscope_runtime/engine/services/agent_state/redis_state_service.py:41: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
  await self._redis.close()
/xxxxxxxxx/.venv/lib/python3.14/site-packages/agentscope_runtime/engine/services/session_history/redis_session_history_service.py:31: DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
  await self._redis.close()
INFO:     Application shutdown complete.
INFO:     Finished server process [45054]
INFO:agentscope_runtime.engine.deployers.local_deployer:FastAPI daemon thread service stopped successfully
```

This comes from `RedisStateService.stop()` and `RedisSessionHistoryService.stop()` calling `await self._redis.close()`.

## Fix
Use the async close method `await self._redis.aclose()` for redis asyncio clients. This matches the redis-py guidance and removes the deprecation warnings.

## Scope
Two call sites:
- `agentscope_runtime/engine/services/agent_state/redis_state_service.py`
- `agentscope_runtime/engine/services/session_history/redis_session_history_service.py`
