### PR TITLE
Fix: improve VNC path parsing robustness

### DIFF
--- a/src/agentscope_runtime/sandbox/box/gui/box/vnc_relay.html
+++ b/src/agentscope_runtime/sandbox/box/gui/box/vnc_relay.html
@@ -111,7 +111,8 @@
             // Supports: /desktop/{sandbox_id}/... or /custom/prefix/desktop/{sandbox_id}/...
             const desktopIndex = pathParts.indexOf('desktop');
             if (desktopIndex !== -1 && pathParts.length > desktopIndex + 1) {
-                return pathParts[desktopIndex + 1];
+                // Return null if sandbox_id is empty (e.g., /desktop/ or /desktop//)
+                return pathParts[desktopIndex + 1] || null;
             }
             return null;
         }
@@ -120,9 +121,12 @@
             // Extract the path prefix up to and including /desktop/{sandbox_id}
             // This preserves any custom URL prefix for reverse proxy deployments
             const currentPath = window.location.pathname;
-            const desktopMatch = currentPath.match(/(.*)\/desktop\/([^\/]+)/);
+            // Use non-greedy matching (.*?) to find the FIRST occurrence of /desktop/
+            // This ensures consistency with getSandboxIdFromPath() which uses indexOf()
+            const desktopMatch = currentPath.match(/(.*?)\/desktop\/([^\/]+)/);
             if (desktopMatch) {
-                return desktopMatch[1] + '/desktop/' + desktopMatch[2];
+                // Use the passed sandbox_id parameter for consistency
+                return desktopMatch[1] + '/desktop/' + sandbox_id;
             }
             // Fallback to simple path
             return '/desktop/' + sandbox_id;


### PR DESCRIPTION
## Description
Address code review suggestions from Copilot on PR #322.

This PR improves the robustness of VNC path parsing in `vnc_relay.html`:

1. **Return null instead of empty string** - When sandbox_id is missing (e.g., `/desktop/` or `/desktop//`), now correctly returns `null` instead of empty string
2. **Use non-greedy regex matching** - Changed `(.*)` to `(.*?)` to find the FIRST occurrence of `/desktop/`, ensuring consistency with `getSandboxIdFromPath()` which uses `indexOf()`
3. **Use passed sandbox_id parameter** - Use the already-extracted `sandbox_id` parameter instead of re-extracting from regex for consistency

**Related Issue:** Follow-up to #322

**Security Considerations:** No security impact. This change only affects URL path parsing logic.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [x] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing
- Verified backward compatibility with simple path: `/desktop/{sandbox_id}/vnc/vnc_relay.html`
- Verified custom URL prefix: `/custom/prefix/desktop/{sandbox_id}/vnc/vnc_relay.html`
- Edge cases handled: `/desktop/`, `/desktop//`