### PR TITLE
Handle existing OpenTelemetry tracer providers safely

### DIFF
--- a/src/agentscope_runtime/engine/tracing/wrapper.py
+++ b/src/agentscope_runtime/engine/tracing/wrapper.py
@@ -928,7 +928,7 @@ def _get_ot_tracer() -> ot_trace.Tracer:
         if isinstance(existing_provider, NoOpTracerProvider):
             return False
         elif isinstance(existing_provider, ProxyTracerProvider):
-            # PorxyTraceProvider will use the _TRACER_PROVIDER as real tracer
+            # ProxyTracerProvider will use the _TRACER_PROVIDER as real tracer
             # provider to get the tracer
             return bool(_TRACER_PROVIDER)
 


### PR DESCRIPTION
## Description

  - Prevents creating duplicate tracer providers and ensures the wrapper resolves the underlying tracer correctly.

  Related Issue: Relates to #N/A

  Security Considerations: None.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] Refactoring

  ## Component(s) Affected

  - [x] Engine
  - [ ] Sandbox
  - [ ] Tools
  - [ ] Common
  - [ ] Documentation
  - [ ] Tests
  - [ ] CI/CD

  ## Checklist

  - [ ] Pre-commit hooks pass
  - [ ] Tests pass locally
  - [ ] Documentation updated (if needed)
  - [x] Ready for review

