### PR TITLE
fix: AGUIAdapterUtils handle additional fields in agent request

### DIFF
--- a/src/agentscope_runtime/engine/deployers/adapter/agui/__init__.py
+++ b/src/agentscope_runtime/engine/deployers/adapter/agui/__init__.py
@@ -5,4 +5,11 @@ from .agui_protocol_adapter import (
     AGUIAdaptorConfig,
 )
 
-__all__ = ["AGUIDefaultAdapter", "FlexibleRunAgentInput", "AGUIAdaptorConfig"]
+from .agui_adapter_utils import AGUIAdapterUtils
+
+__all__ = [
+    "AGUIDefaultAdapter",
+    "FlexibleRunAgentInput",
+    "AGUIAdaptorConfig",
+    "AGUIAdapterUtils",
+]

--- a/src/agentscope_runtime/engine/deployers/adapter/agui/agui_adapter_utils.py
+++ b/src/agentscope_runtime/engine/deployers/adapter/agui/agui_adapter_utils.py
@@ -216,7 +216,7 @@ class AGUI_MESSAGE_STATUS(Enum):
     COMPLETED = "COMPLETED"
 
 
-class AGUIAdapter:
+class AGUIAdapterUtils:
     """
     Utility adapter that converts between Agent API events and AG-UI events.
     """
@@ -285,6 +285,11 @@ class AGUIAdapter:
                 "session_id": self.thread_id,
                 "user_id": user_id,
                 "tools": tools,
+                # extra fields from agui_request
+                "state": agui_request.state,
+                "forwarded_props": agui_request.forwarded_props,
+                "parent_run_id": agui_request.parent_run_id,
+                "context": agui_request.context,
             },
         )
         return agent_request

--- a/src/agentscope_runtime/engine/deployers/adapter/agui/agui_protocol_adapter.py
+++ b/src/agentscope_runtime/engine/deployers/adapter/agui/agui_protocol_adapter.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest, Event
 
 from .agui_adapter_utils import (
-    AGUIAdapter,
+    AGUIAdapterUtils,
     AGUIEvent,
     AGUIEventType,
     RunErrorEvent,
@@ -157,7 +157,7 @@ class AGUIDefaultAdapter(ProtocolAdapter):
         request: FlexibleRunAgentInput,
     ):
         assert self._execution_func is not None
-        adapter = AGUIAdapter(
+        adapter = AGUIAdapterUtils(
             thread_id=request.thread_id,
             run_id=request.run_id,
         )


### PR DESCRIPTION
This change updates the AGUI adapter conversion to preserve extra fields from AG-UI requests (state, forwarded_props, parent_run_id, context) when building AgentRequest.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Engine
- [ ] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [x] Tests
- [ ] CI/CD

## Checklist

- [ ] Pre-commit hooks pass
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Run: pytest tests/unit/test_agui_protocol_adapter.py