### PR TITLE
fix:audio block type check

### DIFF
--- a/src/agentscope_runtime/adapters/agentscope/stream.py
+++ b/src/agentscope_runtime/adapters/agentscope/stream.py
@@ -518,7 +518,7 @@ async def adapt_agentscope_message_stream(
                                 index=index,
                                 **kwargs,
                             )
-                        elif element.get("text") == "audio":
+                        elif element.get("type") == "audio":
                             kwargs = {}
                             if (
                                 isinstance(element.get("source"), dict)


### PR DESCRIPTION
## Summary

- Fix audio block type detection so type=audio is handled correctly.
- Prevent audio content from being misrouted to TextContent.

## Changes

- [[stream.py](app://-/index.html#)](app://-/index.html#): use element.get("type") == "audio".

## Testing

- Not run (not requested).