### PR TITLE
fix(storage): handle OSS folder marker objects in download_folder

### DIFF
--- a/src/agentscope_runtime/sandbox/manager/storage/oss_storage.py
+++ b/src/agentscope_runtime/sandbox/manager/storage/oss_storage.py
@@ -37,7 +37,7 @@ class OSSStorage(DataStorage):
                 os.path.relpath(obj.key, source_path),
             )
 
-            if obj.is_prefix():
+            if obj.is_prefix() or obj.key.endswith("/"):
                 # Create local directory
                 os.makedirs(local_path, exist_ok=True)
             else:


### PR DESCRIPTION
## Summary

Fixes `OSSStorage.download_folder()` incorrectly treating OSS "folder marker" objects (keys ending with `/`, often zero-byte objects) as regular files.

When a bucket contains both:
- `dir/` (marker object)
- `dir/file.txt` (real file)

the previous implementation would download `dir/` to a local *file* named `dir`, and then later fail when trying to create the directory `dir/` for `dir/file.txt` (file/dir name conflict).

## Root cause

`download_folder()` only checked `obj.is_prefix()` to decide whether an entry should be created as a local directory.

However, folder marker objects like `dir/` are real objects in `object_list` (not necessarily common-prefix entries), so they may not satisfy `is_prefix()` and were handled as files.

## Fix

Treat objects with keys ending in `/` as directories:

```py
if obj.is_prefix() or obj.key.endswith("/"):
    os.makedirs(local_path, exist_ok=True)
else:
    ...
```

This preserves empty directories represented by marker objects and prevents local path conflicts.

## How to reproduce

1. Upload two keys into the same prefix:
   - `<prefix>dir/` (empty object)
   - `<prefix>dir/file.txt`
2. Call `download_folder(<prefix>, <local_dir>)`

Before this patch: may fail due to `dir` being created as a file first.
After this patch: `dir/` becomes a local directory and `dir/file.txt` downloads correctly.

## Related issue

Fixes #450
