### PR TITLE
feat: print callback for docker image build

### DIFF
--- a/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/docker_image_builder.py
+++ b/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/docker_image_builder.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import subprocess
-from typing import Optional, Dict
+from typing import Callable, Optional, Dict
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ class BuildConfig(BaseModel):
 
     no_cache: bool = False
     quiet: bool = False
+    print: Callable[[str], None] = print
     build_args: Dict[str, str] = {}
     platform: Optional[str] = None
     target: Optional[str] = None
@@ -177,7 +178,7 @@ class DockerImageBuilder:
                         if output == "" and process.poll() is not None:
                             break
                         if output:
-                            print(output.strip())
+                            config.print(output.strip())
 
                     process.wait()
 
@@ -242,7 +243,7 @@ class DockerImageBuilder:
         self,
         image_name: str,
         registry_config: Optional[RegistryConfig] = None,
-        quiet: bool = False,
+        build_config: Optional[BuildConfig] = None,
     ) -> str:
         """
         Push image to registry.
@@ -251,7 +252,7 @@ class DockerImageBuilder:
             image_name: Full image name to push
             registry_config: Optional registry config
                 (uses instance config if None)
-            quiet: Whether to suppress output
+            build_config: Build configuration
 
         Returns:
             str: Full image name that was pushed
@@ -261,11 +262,12 @@ class DockerImageBuilder:
             ValueError: If no registry configuration is available
         """
         registry_image_name = self.tag_image(image_name, registry_config)
+        build_config = build_config or BuildConfig()
 
         try:
             push_cmd = ["docker", "push", registry_image_name]
 
-            if quiet:
+            if build_config.quiet:
                 result = subprocess.run(
                     push_cmd,
                     check=True,
@@ -292,7 +294,7 @@ class DockerImageBuilder:
                         if output == "" and process.poll() is not None:
                             break
                         if output:
-                            print(output.strip())
+                            build_config.print(output.strip())
 
                     process.wait()
 
@@ -359,7 +361,7 @@ class DockerImageBuilder:
         registry_image = self.push_image(
             image_name=built_image,
             registry_config=registry_config,
-            quiet=build_config.quiet if build_config else False,
+            build_config=build_config,
         )
 
         # make sure return the built name without registry

--- a/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/image_factory.py
+++ b/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/image_factory.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import logging
 import os
-from typing import Optional, List, Dict, Union
+from typing import Callable, Optional, List, Dict, Union
 
 from pydantic import BaseModel, Field
 
@@ -52,6 +52,7 @@ class ImageConfig(BaseModel):
     # Build configuration
     no_cache: bool = False
     quiet: bool = False
+    print: Callable[[str], None] = print
     build_args: Dict[str, str] = {}
     platform: Optional[str] = None
 
@@ -249,6 +250,7 @@ class ImageFactory:
             build_config = BuildConfig(
                 no_cache=config.no_cache,
                 quiet=config.quiet,
+                print=config.print,
                 build_args=config.build_args,
                 source_updated=is_updated,
                 platform=config.platform,


### PR DESCRIPTION
## Description
Make `print` not a bare function, but a callback function which we could determine in [`BuildConfig`](https://github.com/agentscope-ai/agentscope-runtime/blob/main/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/docker_image_builder.py#L30).

在输出构建日志时不使用裸的 `print` ，而是修改成一个回调函数，允许我们在 [`BuildConfig`](https://github.com/agentscope-ai/agentscope-runtime/blob/main/src/agentscope_runtime/engine/deployers/utils/docker_image_utils/docker_image_builder.py#L30) 中指定。

**Related Issue:** Fix #480

**Security Considerations:** None, I suppose

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Engine
- [ ] Sandbox
- [ ] Tools
- [ ] Common
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [ ] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
Add a `print=foo` param in `app.deploy()`.

在 `app.deploy()` 中加入 `print` 参数即可测试。

## Additional Notes
Unless explicitly set, there is no change in behavior.

除非显式设置，否则行为上没有改变。