### PR TITLE
fix: prefer IPv4 address in dual-stack Kubernetes clusters

### DIFF
--- a/src/agentscope_runtime/common/container_clients/kubernetes_client.py
+++ b/src/agentscope_runtime/common/container_clients/kubernetes_client.py
@@ -646,19 +646,30 @@ class KubernetesClient(BaseClient):
 
             node = self.v1.read_node(name=node_name)
 
-            external_ip = None
-            internal_ip = None
+            ipv4_external = None
+            ipv4_internal = None
+            any_external = None
+            any_internal = None
 
             for address in node.status.addresses:
                 if address.type == "ExternalIP":
-                    external_ip = address.address
+                    any_external = address.address
+                    if ":" not in address.address:
+                        ipv4_external = address.address
                 elif address.type == "InternalIP":
-                    internal_ip = address.address
+                    any_internal = address.address
+                    if ":" not in address.address:
+                        ipv4_internal = address.address
 
-            result_ip = external_ip or internal_ip
+            result_ip = (
+                ipv4_external or ipv4_internal or any_external or any_internal
+            )
             logger.debug(
-                f"Using IP: {result_ip} (external: {external_ip}, internal:"
-                f" {internal_ip})",
+                "Node IP for pod %s: %s (ipv4_ext=%s, ipv4_int=%s)",
+                pod_name,
+                result_ip,
+                ipv4_external,
+                ipv4_internal,
             )
             return result_ip
 
@@ -1005,8 +1016,7 @@ class KubernetesClient(BaseClient):
                 # Check if deployment is ready
                 if (
                     deployment.status.ready_replicas
-                    and deployment.status.ready_replicas
-                    == deployment.spec.replicas
+                    and deployment.status.ready_replicas == deployment.spec.replicas
                 ):
                     return True
 
@@ -1101,10 +1111,8 @@ class KubernetesClient(BaseClient):
                 "name": deployment_name,
                 "replicas": deployment.spec.replicas,
                 "ready_replicas": deployment.status.ready_replicas or 0,
-                "available_replicas": deployment.status.available_replicas
-                or 0,
-                "unavailable_replicas": deployment.status.unavailable_replicas
-                or 0,
+                "available_replicas": deployment.status.available_replicas or 0,
+                "unavailable_replicas": deployment.status.unavailable_replicas or 0,
                 "conditions": [
                     {
                         "type": condition.type,
@@ -1132,9 +1140,7 @@ class KubernetesClient(BaseClient):
                 namespace=self.namespace,
                 label_selector=label_selector,
             )
-            return [
-                deployment.metadata.name for deployment in deployments.items
-            ]
+            return [deployment.metadata.name for deployment in deployments.items]
         except ApiException as e:
             logger.error(f"Failed to list deployments: {e.reason}")
             return []

--- a/tests/unit/test_kubernetes_client_ipv4.py
+++ b/tests/unit/test_kubernetes_client_ipv4.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name, protected-access
+"""
+Unit tests for KubernetesClient._get_pod_node_ip IPv4 preference logic.
+"""
+
+from unittest.mock import MagicMock, patch
+import types
+
+import pytest
+
+from agentscope_runtime.common.container_clients.kubernetes_client import (
+    KubernetesClient,
+)
+
+
+class MockConfig:
+    """Mock config object for KubernetesClient."""
+
+    def __init__(self):
+        self.k8s_namespace = "test-namespace"
+        self.kubeconfig_path = None
+
+
+@pytest.fixture
+def mock_k8s_client():
+    """Create a KubernetesClient with mocked API."""
+    with patch(
+        "agentscope_runtime.common.container_clients"
+        ".kubernetes_client.k8s_config.load_incluster_config",
+    ):
+        with patch(
+            "agentscope_runtime.common.container_clients"
+            ".kubernetes_client.client.CoreV1Api",
+        ) as mock_v1:
+            mock_v1.return_value.list_namespace.return_value = MagicMock()
+            client = KubernetesClient(config=MockConfig())
+            yield client
+
+
+class MockAddress:
+    """Simple mock for node address."""
+
+    def __init__(self, addr_type, addr_value):
+        self.type = addr_type
+        self.address = addr_value
+
+
+def make_node(addresses):
+    """Build a mock node object with given addresses."""
+    node = types.SimpleNamespace()
+    node.status = types.SimpleNamespace()
+    node.status.addresses = [
+        MockAddress(addr_type, addr_value)
+        for addr_type, addr_value in addresses
+    ]
+    return node
+
+
+def make_pod(node_name):
+    """Build a mock pod object with given node name."""
+    pod = MagicMock()
+    pod.spec.node_name = node_name
+    return pod
+
+
+class TestGetPodNodeIp:
+    """Tests for _get_pod_node_ip IPv4 preference."""
+
+    def test_ipv4_preferred_over_ipv6(self, mock_k8s_client):
+        """IPv4 address should be preferred over IPv6 in dual-stack nodes."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(
+            "worker-node-1",
+        )
+        mock_k8s_client.v1.read_node.return_value = make_node(
+            [
+                ("InternalIP", "10.0.0.5"),
+                ("InternalIP", "fd00::5"),
+                ("ExternalIP", "203.0.113.10"),
+            ]
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "203.0.113.10"
+
+    def test_ipv4_internal_preferred_over_ipv6_external(self, mock_k8s_client):
+        """IPv4 internal should be preferred over IPv6 external."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(
+            "worker-node-1",
+        )
+        mock_k8s_client.v1.read_node.return_value = make_node(
+            [
+                ("InternalIP", "10.0.0.5"),
+                ("ExternalIP", "fd00::1"),
+            ]
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "10.0.0.5"
+
+    def test_ipv6_used_when_no_ipv4(self, mock_k8s_client):
+        """IPv6 address should be used when no IPv4 is available."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(
+            "worker-node-1",
+        )
+        mock_k8s_client.v1.read_node.return_value = make_node(
+            [
+                ("InternalIP", "fe80::1"),
+                ("ExternalIP", "fd00::1"),
+            ]
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "fd00::1"
+
+    def test_only_ipv4_internal(self, mock_k8s_client):
+        """Only IPv4 internal IP available should be returned."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(
+            "worker-node-1",
+        )
+        mock_k8s_client.v1.read_node.return_value = make_node(
+            [
+                ("InternalIP", "10.0.0.5"),
+            ]
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "10.0.0.5"
+
+    def test_external_preferred_over_internal_ipv4(self, mock_k8s_client):
+        """IPv4 external should be preferred over IPv4 internal."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(
+            "worker-node-1",
+        )
+        mock_k8s_client.v1.read_node.return_value = make_node(
+            [
+                ("InternalIP", "10.0.0.5"),
+                ("ExternalIP", "203.0.113.10"),
+            ]
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "203.0.113.10"
+
+    def test_local_cluster_returns_localhost(self, mock_k8s_client):
+        """Local cluster should return localhost without API calls."""
+        with patch.object(
+            mock_k8s_client,
+            "_is_local_cluster",
+            return_value=True,
+        ):
+            result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result == "localhost"
+        mock_k8s_client.v1.read_namespaced_pod.assert_not_called()
+
+    def test_unscheduled_pod_returns_none(self, mock_k8s_client):
+        """Pod without node assignment should return None."""
+        mock_k8s_client.v1.read_namespaced_pod.return_value = make_pod(None)
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result is None
+
+    def test_exception_returns_none(self, mock_k8s_client):
+        """API exception should return None gracefully."""
+        mock_k8s_client.v1.read_namespaced_pod.side_effect = Exception(
+            "API error",
+        )
+
+        result = mock_k8s_client._get_pod_node_ip("test-pod")
+
+        assert result is None


### PR DESCRIPTION
## Summary

实际工作使用中，发现双栈 Kubernetes 集群中，`_get_pod_node_ip` 方法返回的节点IP顺序不确定，经常返回 IPv6 地址导致 NodePort 无法访问。

## Changes

- 在 `_get_pod_node_ip` 中增加 IPv4 优先逻辑：通过检测地址中是否包含 `:` 来区分 IPv4/IPv6
- 优先选择 IPv4 外部/内部地址，无 IPv4 时 fallback 到 IPv6
- 改善 debug 日志，显示 IPv4 vs IPv6 的详细分组

## Test Plan

- 新增 `tests/unit/test_kubernetes_client_ipv4.py`，覆盖 8 个测试用例：
  - IPv4 优先于 IPv6
  - 纯 IPv4 场景
  - 纯 IPv6 场景（fallback）
  - 外部/内部地址优先级
  - 本地集群、Pod 未调度、异常处理