### PR TITLE
docs: add archive notice for AgentScope 2.0 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> **This repository will be archived soon.** With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into the AgentScope 2.0 framework.
+> With the release of AgentScope 2.0 (https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
 >
-> We recommend all users migrate to AgentScope 2.0 for continued updates, new features, and community support. This repository will remain available in read-only mode for reference.
+> We recommend all users migrate to AgentScope 2.0 for continued updates, new features and community support. This repository will remain available in read-only mode for reference. **This repository will be archived soon.**
 >
 > Thank you to everyone who contributed to and used AgentScope Runtime!
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> All capabilities of this repository — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into [AgentScope 2.0](https://github.com/agentscope-ai/agentscope). We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support.
+> With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
 >
-> This repository will remain available in read-only mode for reference and will be archived soon. Thank you to everyone who contributed to and used AgentScope Runtime!
+> We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support. This repository will remain available in read-only mode for reference and will be archived soon.
+>
+> Thank you to everyone who contributed to and used AgentScope Runtime!
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> ## Archive Notice
+>
+> **This repository will be archived soon.** With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into the AgentScope 2.0 framework.
+>
+> We recommend all users migrate to AgentScope 2.0 for continued updates, new features, and community support. This repository will remain available in read-only mode for reference.
+>
+> Thank you to everyone who contributed to and used AgentScope Runtime!
+
 <div align="center">
 
 # AgentScope Runtime: A Production-grade Runtime for Agent Applications

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> With the release of AgentScope 2.0 (https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
+> All capabilities of this repository — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into [AgentScope 2.0](https://github.com/agentscope-ai/agentscope). We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support.
 >
-> We recommend all users migrate to AgentScope 2.0 for continued updates, new features and community support. This repository will remain available in read-only mode for reference. **This repository will be archived soon.**
->
-> Thank you to everyone who contributed to and used AgentScope Runtime!
+> This repository will remain available in read-only mode for reference and will be archived soon. Thank you to everyone who contributed to and used AgentScope Runtime!
 
 <div align="center">
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,11 +1,9 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> 随着 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
+> 本仓库的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope)。我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。
 >
-> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。**本仓库即将被归档（Archive）。**
->
-> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+> 本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 
 <div align="center">
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> ## 归档公告
+>
+> **本仓库即将被归档（Archive）。** 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0 框架。
+>
+> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。
+>
+> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+
 <div align="center">
 
 # AgentScope Runtime：一个生产级的智能体应用运行时框架

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> **本仓库即将被归档（Archive）。** 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0 框架。
+> 随着 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
 >
-> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。
+> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。**本仓库即将被归档（Archive）。**
 >
 > 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,9 +1,11 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> 本仓库的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope)。我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。
+> 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
 >
-> 本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+> 我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。
+>
+> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 
 <div align="center">
 

--- a/cookbook/en/intro.md
+++ b/cookbook/en/intro.md
@@ -1,11 +1,9 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> With the release of AgentScope 2.0 (https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
+> All capabilities of this repository — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into [AgentScope 2.0](https://github.com/agentscope-ai/agentscope). We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support.
 >
-> We recommend all users migrate to AgentScope 2.0 for continued updates, new features and community support. This repository will remain available in read-only mode for reference. **This repository will be archived soon.**
->
-> Thank you to everyone who contributed to and used AgentScope Runtime!
+> This repository will remain available in read-only mode for reference and will be archived soon. Thank you to everyone who contributed to and used AgentScope Runtime!
 
 # Welcome to AgentScope Runtime Cookbook
 

--- a/cookbook/en/intro.md
+++ b/cookbook/en/intro.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> **This repository will be archived soon.** With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into the AgentScope 2.0 framework.
+> With the release of AgentScope 2.0 (https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
 >
-> We recommend all users migrate to AgentScope 2.0 for continued updates, new features, and community support. This repository will remain available in read-only mode for reference.
+> We recommend all users migrate to AgentScope 2.0 for continued updates, new features and community support. This repository will remain available in read-only mode for reference. **This repository will be archived soon.**
 >
 > Thank you to everyone who contributed to and used AgentScope Runtime!
 

--- a/cookbook/en/intro.md
+++ b/cookbook/en/intro.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> ## Archive Notice
+>
+> **This repository will be archived soon.** With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into the AgentScope 2.0 framework.
+>
+> We recommend all users migrate to AgentScope 2.0 for continued updates, new features, and community support. This repository will remain available in read-only mode for reference.
+>
+> Thank you to everyone who contributed to and used AgentScope Runtime!
+
 # Welcome to AgentScope Runtime Cookbook
 
 [![GitHub Repo](https://img.shields.io/badge/GitHub-Repo-black.svg?logo=github)](https://github.com/agentscope-ai/agentscope-runtime)

--- a/cookbook/en/intro.md
+++ b/cookbook/en/intro.md
@@ -1,9 +1,11 @@
 > [!IMPORTANT]
 > ## Archive Notice
 >
-> All capabilities of this repository — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into [AgentScope 2.0](https://github.com/agentscope-ai/agentscope). We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support.
+> With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
 >
-> This repository will remain available in read-only mode for reference and will be archived soon. Thank you to everyone who contributed to and used AgentScope Runtime!
+> We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support. This repository will remain available in read-only mode for reference and will be archived soon.
+>
+> Thank you to everyone who contributed to and used AgentScope Runtime!
 
 # Welcome to AgentScope Runtime Cookbook
 

--- a/cookbook/en/intro.md
+++ b/cookbook/en/intro.md
@@ -1,13 +1,12 @@
-> [!IMPORTANT]
-> ## Archive Notice
->
-> With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
->
-> We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support. This repository will remain available in read-only mode for reference and will be archived soon.
->
-> Thank you to everyone who contributed to and used AgentScope Runtime!
-
 # Welcome to AgentScope Runtime Cookbook
+
+```{important} Archive Notice
+With the release of [AgentScope 2.0](https://github.com/agentscope-ai/agentscope), all capabilities of AgentScope Runtime — including tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into AgentScope 2.0.
+
+We recommend all users migrate to AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) for continued updates, new features and community support. This repository will remain available in read-only mode for reference and will be archived soon.
+
+Thank you to everyone who contributed to and used AgentScope Runtime!
+```
 
 [![GitHub Repo](https://img.shields.io/badge/GitHub-Repo-black.svg?logo=github)](https://github.com/agentscope-ai/agentscope-runtime)
 [![WebUI](https://img.shields.io/badge/Try_WebUI-Online-green.svg?logo=googlechrome)](http://webui.runtime.agentscope.io/)

--- a/cookbook/zh/intro.md
+++ b/cookbook/zh/intro.md
@@ -1,11 +1,9 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> 随着 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
+> 本仓库的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope)。我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。
 >
-> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。**本仓库即将被归档（Archive）。**
->
-> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+> 本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 
 # 欢迎来到AgentScope Runtime Cookbook
 

--- a/cookbook/zh/intro.md
+++ b/cookbook/zh/intro.md
@@ -1,9 +1,11 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> 本仓库的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope)。我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。
+> 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
 >
-> 本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+> 我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。
+>
+> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 
 # 欢迎来到AgentScope Runtime Cookbook
 

--- a/cookbook/zh/intro.md
+++ b/cookbook/zh/intro.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
 > ## 归档公告
 >
-> **本仓库即将被归档（Archive）。** 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0 框架。
+> 随着 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
 >
-> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。
+> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。**本仓库即将被归档（Archive）。**
 >
 > 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
 

--- a/cookbook/zh/intro.md
+++ b/cookbook/zh/intro.md
@@ -1,13 +1,12 @@
-> [!IMPORTANT]
-> ## 归档公告
->
-> 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
->
-> 我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。
->
-> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
-
 # 欢迎来到AgentScope Runtime Cookbook
+
+```{important} 归档公告
+随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0。
+
+我们建议所有用户迁移至 AgentScope 2.0 (https://github.com/agentscope-ai/agentscope)，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留供参考，并将于近期归档（Archive）。
+
+感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+```
 
 [![GitHub Repo](https://img.shields.io/badge/GitHub-Repo-black.svg?logo=github)](https://github.com/agentscope-ai/agentscope-runtime)
 [![WebUI](https://img.shields.io/badge/Try_WebUI-Online-green.svg?logo=googlechrome)](http://webui.runtime.agentscope.io/)

--- a/cookbook/zh/intro.md
+++ b/cookbook/zh/intro.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> ## 归档公告
+>
+> **本仓库即将被归档（Archive）。** 随着 [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) 的发布，AgentScope Runtime 的所有核心能力——包括工具沙箱化、Agent 即服务（AaaS）API 以及全栈可观测性——均已被原生集成至 AgentScope 2.0 框架。
+>
+> 我们建议所有用户迁移至 AgentScope 2.0，以获得持续更新、新功能及社区支持。本仓库将以只读模式继续保留，供参考使用。
+>
+> 感谢每一位为 AgentScope Runtime 做出贡献和使用本项目的开发者！
+
 # 欢迎来到AgentScope Runtime Cookbook
 
 [![GitHub Repo](https://img.shields.io/badge/GitHub-Repo-black.svg?logo=github)](https://github.com/agentscope-ai/agentscope-runtime)


### PR DESCRIPTION
## Description
Add archive notice to README (EN/ZH) and Cookbook intro pages (EN/ZH), informing users that this repository will be archived as all its capabilities — tool sandboxing, Agent-as-a-Service APIs, and full-stack observability — have been natively integrated into the AgentScope 2.0 framework.

The notice directs users to migrate to [AgentScope 2.0](https://github.com/agentscope-ai/agentscope) for continued updates and support.

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Engine
- [ ] Sandbox
- [ ] Tools
- [ ] Common
- [x] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [x] Pre-commit hooks pass
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
Visual inspection — verify the `[!IMPORTANT]` callout renders correctly on GitHub (README) and Jupyter Book (Cookbook).

## Additional Notes
After this PR is merged, the repository should be archived via GitHub Settings.
