### PR TITLE
fix(engine): use default_factory for BaseResponse.created_at

### DIFF
--- a/src/agentscope_runtime/engine/schemas/agent_schemas.py
+++ b/src/agentscope_runtime/engine/schemas/agent_schemas.py
@@ -885,7 +885,7 @@ class BaseResponse(Event):
     status: str = RunStatus.Created
     """response run status"""
 
-    created_at: int = int(datetime.now().timestamp())
+    created_at: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
     """request start time"""
 
     completed_at: Optional[int] = None


### PR DESCRIPTION
## Summary

Fixes agentscope-ai/QwenPaw#4740

The static default for `BaseResponse.created_at` is evaluated once at class definition time, causing all `AgentResponse` instances within the same process to share the same timestamp — the server startup time.

## Root Cause

```python
# Line 888 — evaluated ONCE when module loads
created_at: int = int(datetime.now().timestamp())
```

This means every streaming SSE event sent to the frontend carries the same stale `created_at`, so the console display shows incorrect timing for all responses after the first.

## Fix

Replace the static default with `Field(default_factory=...)` so each instance gets a fresh timestamp:

```python
created_at: int = Field(default_factory=lambda: int(datetime.now().timestamp()))
```

## Testing

Verified that two `BaseResponse` instances created 2 seconds apart now have different `created_at` values.

---

*Bug identified and fix generated with [GitWire](https://gitwire.erlab.uk) — self-hosted AI governance for GitHub automation.*