### PR TITLE
fix(engine): map Celery STARTED/RETRY/REVOKED states in get_task_status

### DIFF
--- a/src/agentscope_runtime/engine/deployers/utils/service_utils/routing/task_engine_mixin.py
+++ b/src/agentscope_runtime/engine/deployers/utils/service_utils/routing/task_engine_mixin.py
@@ -352,6 +352,16 @@ class TaskEngineMixin:
             result = self.celery_app.AsyncResult(task_id)
             if result.state == "PENDING":
                 return {"status": "pending", "result": None}
+            elif result.state == "STARTED":
+                return {
+                    "status": "running",
+                    "started_at": result.info.get("started_at") if isinstance(result.info, dict) else None,
+                    "result": None,
+                }
+            elif result.state == "RETRY":
+                return {"status": "running", "result": None}
+            elif result.state == "REVOKED":
+                return {"status": "error", "result": "Task was revoked"}
             elif result.state == "SUCCESS":
                 return {"status": "finished", "result": result.result}
             elif result.state == "FAILURE":


### PR DESCRIPTION
## Summary

Fixes #485

The Celery code path in `get_task_status()` only mapped 3 of Celery's task states (PENDING, SUCCESS, FAILURE). Three additional states were unhandled:

| Celery State | Before | After |
|---|---|---|
| `STARTED` | Falls to else → raw state string | `running` with optional `started_at` |
| `RETRY` | Falls to else → raw state string | `running` |
| `REVOKED` | Falls to else → raw state string | `error` with descriptive message |

This prevented API consumers from distinguishing between a queued task and one that is actively executing.

## Changes

Added explicit mappings for `STARTED`, `RETRY`, and `REVOKED` in the Celery branch of `get_task_status()`, consistent with the non-Celery (in-memory) path that already distinguishes `submitted` → `pending` vs `running` → `running`.

## Testing

Validated all 8 state mappings (PENDING, STARTED with metadata, RETRY, REVOKED, SUCCESS, FAILURE, and unknown passthrough) with standalone unit tests. Existing integration tests in `test_agent_app_stream_task.py` continue to cover the non-Celery path.

---

*Bug identified and fix generated with [GitWire](https://gitwire.erlab.uk) — self-hosted AI governance for GitHub automation.*